### PR TITLE
Update requirements_cu128.txt

### DIFF
--- a/requirements_cu128.txt
+++ b/requirements_cu128.txt
@@ -1,9 +1,11 @@
---index-url https://download.pytorch.org/whl/nightly/cu128
+--index-url https://download.pytorch.org/whl/cu128
 --extra-index-url https://pypi.org/simple
 --pre
 
-torch==2.7.0.dev20250226+cu128
-torchvision==0.22.0.dev20250227+cu128
+xformers==0.0.30
+torch==2.7.0+cu128
+torchvision==0.22.0+cu128
+torchaudio==2.7.0+cu128
 
 argparse
 opencv-contrib-python


### PR DESCRIPTION
Updated torch version references from no longer existing nightly to standard 2.7.0+cu128 binaries. Added version number to Xformers since requirements_cu126 would install xformers v0.0.29.post3 or similar which is not built for pyTorch 2.7.0 as the rest is.